### PR TITLE
Fix for java.nio.charset.IllegalCharsetNameException: utf-8"

### DIFF
--- a/axis-rt-core/src/main/java/org/apache/axis/attachments/MimeUtils.java
+++ b/axis-rt-core/src/main/java/org/apache/axis/attachments/MimeUtils.java
@@ -249,7 +249,7 @@ public class MimeUtils {
 
             if(sendType == Attachments.SEND_TYPE_MTOM) {
                 multipart = new javax.mail.internet.MimeMultipart(
-                        "related;type=\"application/xop+xml\"; start=\"<" + rootCID + ">\"; start-info=\"text/xml; charset=utf-8\"");
+                        "related;type=\"application/xop+xml\"; start=\"<" + rootCID + ">\"; start-info=\"text/xml\"; charset=\"utf-8\"");
             } else {
                 multipart = new javax.mail.internet.MimeMultipart(
                         "related; type=\"text/xml\"; start=\"<" + rootCID + ">\"");


### PR DESCRIPTION
In Weblogic 14c, when executing an MTOM SOAP Request, we are faced with the following exception:

```html
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Draft//EN">
<HTML>
<HEAD>
<TITLE>Error 500--Internal Server Error</TITLE>
</HEAD>
<BODY bgcolor="white">
<FONT FACE=Helvetica><BR CLEAR=all>
<TABLE border=0 cellspacing=5><TR><TD><BR CLEAR=all>
<FONT FACE="Helvetica" COLOR="black" SIZE="3"><H2>Error 500--Internal Server Error</H2>
</FONT></TD></TR>
</TABLE>
<TABLE border=0 width=100% cellpadding=10><TR><TD VALIGN=top WIDTH=100% BGCOLOR=white><FONT FACE="Courier New"><pre>java.nio.charset.IllegalCharsetNameException: utf-8&quot;
	at java.nio.charset.Charset.checkName(Charset.java:315)
	at java.nio.charset.Charset.lookup2(Charset.java:484)
	at java.nio.charset.Charset.lookup(Charset.java:464)
	at java.nio.charset.Charset.isSupported(Charset.java:505)
	at weblogic.servlet.internal.ChunkOutput.getCharset(ChunkOutput.java:249)
	at weblogic.servlet.internal.ChunkOutput.create(ChunkOutput.java:201)
	at weblogic.servlet.internal.ChunkOutputWrapper.changeToCharset(ChunkOutputWrapper.java:73)
	at weblogic.servlet.internal.ServletResponseImpl.setEncoding(ServletResponseImpl.java:1329)
	at weblogic.servlet.internal.ServletResponseImpl.setContentType(ServletResponseImpl.java:521)
	at org.apache.axis.transport.http.AxisServlet.sendResponse(AxisServlet.java:872)
	at org.apache.axis.transport.http.AxisServlet.doPost(AxisServlet.java:762)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:665)
	at org.apache.axis.transport.http.AxisServletBase.service(AxisServletBase.java:332)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:750)
	at weblogic.servlet.internal.StubSecurityHelper$ServletServiceAction.run(StubSecurityHelper.java:295)
	at weblogic.servlet.internal.StubSecurityHelper$ServletServiceAction.run(StubSecurityHelper.java:260)
	at weblogic.servlet.internal.StubSecurityHelper.invokeServlet(StubSecurityHelper.java:137)
	at weblogic.servlet.internal.ServletStubImpl.execute(ServletStubImpl.java:353)
	at weblogic.servlet.internal.ServletStubImpl.execute(ServletStubImpl.java:250)
	at weblogic.servlet.internal.WebAppServletContext$ServletInvocationAction.wrapRun(WebAppServletContext.java:3862)
	at weblogic.servlet.internal.WebAppServletContext$ServletInvocationAction.run(WebAppServletContext.java:3829)
	at weblogic.security.acl.internal.AuthenticatedSubject.doAs(AuthenticatedSubject.java:344)
	at weblogic.security.service.SecurityManager.runAsForUserCode(SecurityManager.java:197)
	at weblogic.servlet.provider.WlsSecurityProvider.runAsForUserCode(WlsSecurityProvider.java:203)
	at weblogic.servlet.provider.WlsSubjectHandle.run(WlsSubjectHandle.java:71)
	at weblogic.servlet.internal.WebAppServletContext.processSecuredExecute(WebAppServletContext.java:2502)
	at weblogic.servlet.internal.WebAppServletContext.doSecuredExecute(WebAppServletContext.java:2351)
	at weblogic.servlet.internal.WebAppServletContext.securedExecute(WebAppServletContext.java:2326)
	at weblogic.servlet.internal.WebAppServletContext.execute(WebAppServletContext.java:2304)
	at weblogic.servlet.internal.ServletRequestImpl.runInternal(ServletRequestImpl.java:1779)
	at weblogic.servlet.internal.ServletRequestImpl.run(ServletRequestImpl.java:1733)
	at weblogic.servlet.provider.ContainerSupportProviderImpl$WlsRequestExecutor.run(ContainerSupportProviderImpl.java:272)
	at weblogic.invocation.ComponentInvocationContextManager._runAs(ComponentInvocationContextManager.java:352)
	at weblogic.invocation.ComponentInvocationContextManager.runAs(ComponentInvocationContextManager.java:337)
	at weblogic.work.LivePartitionUtility.doRunWorkUnderContext(LivePartitionUtility.java:57)
	at weblogic.work.PartitionUtility.runWorkUnderContext(PartitionUtility.java:41)
	at weblogic.work.SelfTuningWorkManagerImpl.runWorkUnderContext(SelfTuningWorkManagerImpl.java:651)
	at weblogic.work.ExecuteThread.execute(ExecuteThread.java:420)
	at weblogic.work.ExecuteThread.run(ExecuteThread.java:360)
</pre></FONT></TD></TR>
</TABLE>

</BODY>
</HTML>
```

This appears to be happening due to this line in `org.apache.axis.attachments.MimeUtils`:

```java
multipart = new javax.mail.internet.MimeMultipart(
                        "related;type=\"application/xop+xml\"; start=\"<" + rootCID + ">\"; start-info=\"text/xml; charset=utf-8\"");
```

You can see that both `start-info` and `charset` are combined into a single header. The fix is to split the `start-info` and `charset` attributes to separate headers like this:

```java
multipart = new javax.mail.internet.MimeMultipart(
                        "related;type=\"application/xop+xml\"; start=\"<" + rootCID + ">\"; start-info=\"text/xml\"; charset=\"utf-8\"");
```

After the code change, the issue is not reproducible.